### PR TITLE
fix(perf) `{:in, keys}` queries to use key-indexed ETS lookups instead of full table scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   than the one entry for that key. Keys are now bound directly in the match
   head, or compared as literal `{:const, key}` terms when that isn't
   possible (e.g. `:_`, `:"$N"` atoms, maps, structs), so reserved-looking
-  keys are always matched as literal values.
+  keys are always matched as literal values. `count_all`, `delete_all`, and
+  `stream` batch all such non-indexable keys given in one call into a
+  single table scan, instead of scanning once per such key.
 - [Nebulex.Adapters.Local] Duplicate keys given to `{:in, keys}` queries are
   now processed once instead of once per occurrence.
 - [Nebulex.Adapters.Local] `{:in, keys}` queries no longer silently ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,35 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   write had already stored for the same key; the promotion now uses
   `insert_new`, so the concurrent write wins.
   [#10](https://github.com/elixir-nebulex/nebulex_local/issues/10).
+- [Nebulex.Adapters.Local] Fixed severe performance degradation of `get_all`,
+  `count_all`, `delete_all`, and `stream` with `{:in, keys}` queries. Keys are
+  now bound in the ETS match head (or fetched per key), so ETS uses the key
+  index instead of scanning the whole table per chunk of keys — O(keys)
+  instead of O(table size × keys). The same fix applies to the older
+  generation purge performed by `put_all` and `put_new_all`; consequently,
+  the `:purge_chunk_size` option is now deprecated and ignored.
+  [#8](https://github.com/elixir-nebulex/nebulex_local/issues/8).
+- [Nebulex.Adapters.Local] Fixed a data-loss bug in `{:in, keys}` queries: a
+  key shaped like a match-spec variable (e.g. `:"$1"`) was compared inside
+  the ETS match-spec guard, where it became a self-referential variable
+  (`{:"=:=", :"$1", :"$1"}`, always true) instead of a literal value — so
+  e.g. `delete_all(in: [:"$1"])` deleted every entry in the table rather
+  than the one entry for that key. Keys are now bound directly in the match
+  head, or compared as literal `{:const, key}` terms when that isn't
+  possible (e.g. `:_`, `:"$N"` atoms, maps, structs), so reserved-looking
+  keys are always matched as literal values.
+- [Nebulex.Adapters.Local] Duplicate keys given to `{:in, keys}` queries are
+  now processed once instead of once per occurrence.
+- [Nebulex.Adapters.Local] `{:in, keys}` queries no longer silently ignore
+  entries written with the `:tag` option, and `stream/2` no longer crashes
+  when the given keys are tuples.
+- [Nebulex.Adapters.Local] `get_all` with `{:in, keys}` now moves entries from
+  the older generation into the newer one and lazily removes expired entries
+  on read (like `fetch/2`), restoring the v2 read behavior. Note: entries
+  removed this way during `get_all`, `count_all`, or `delete_all` with
+  `{:in, keys}` are not currently reflected in the
+  evictions/expirations/deletions stats counters; fixing that needs a change
+  in Nebulex core, not this adapter.
 
 ## [v3.0.0](https://github.com/elixir-nebulex/nebulex_local/tree/v3.0.0) (2026-02-21)
 > [Full Changelog](https://github.com/elixir-nebulex/nebulex_local/compare/v3.0.0-rc.2...v3.0.0)

--- a/lib/nebulex/adapters/local.ex
+++ b/lib/nebulex/adapters/local.ex
@@ -289,6 +289,14 @@ defmodule Nebulex.Adapters.Local do
     * `count_all` and `delete_all` neither count nor delete expired entries.
     * `stream` is read-only; it does not move entries across generations nor
       remove expired ones.
+    * Keys that can't be bound in an ETS match head — `:_`, `:"$N"` atoms,
+      maps, structs, or terms containing them — aren't indexable. `get_all`
+      is unaffected, since it looks these up directly. `count_all`,
+      `delete_all`, and `stream` instead match every such key given in one
+      call with a single extra table scan (not one scan per key), so a call
+      that mixes a few of these keys among many ordinary ones stays cheap;
+      a call given only such keys still costs one scan proportional to the
+      cache size.
 
   ## Building Match Specs with QueryHelper
 
@@ -1326,12 +1334,24 @@ defmodule Nebulex.Adapters.Local do
   defp select_keys(meta_tab, backend, keys, select) do
     now = Time.now()
     generations = list_gen(meta_tab)
+    {safe, unsafe} = Enum.split_with(keys, &safe_match_head_key?/1)
 
-    Enum.flat_map(keys, fn key ->
-      ms = key_match_spec(key, select, now)
+    safe_results =
+      Enum.flat_map(safe, fn key ->
+        ms = key_match_spec(key, select, now)
 
-      Enum.flat_map(generations, &backend.select(&1, ms))
-    end)
+        Enum.flat_map(generations, &backend.select(&1, ms))
+      end)
+
+    case unsafe do
+      [] ->
+        safe_results
+
+      _ ->
+        ms = unsafe_keys_match_spec(unsafe, select, now)
+
+        safe_results ++ Enum.flat_map(generations, &backend.select(&1, ms))
+    end
   end
 
   ## Nebulex.Adapter.Info
@@ -1622,15 +1642,31 @@ defmodule Nebulex.Adapters.Local do
   end
 
   defp do_count_all(backend, tab, keys, now) do
-    Enum.reduce(keys, 0, fn key, acc ->
-      backend.select_count(tab, key_match_spec(key, now)) + acc
-    end)
+    {safe, unsafe} = Enum.split_with(keys, &safe_match_head_key?/1)
+
+    count =
+      Enum.reduce(safe, 0, fn key, acc ->
+        backend.select_count(tab, key_match_spec(key, now)) + acc
+      end)
+
+    case unsafe do
+      [] -> count
+      _ -> count + backend.select_count(tab, unsafe_keys_match_spec(unsafe, now))
+    end
   end
 
   defp do_delete_all(backend, tab, keys, now) do
-    Enum.reduce(keys, 0, fn key, acc ->
-      backend.select_delete(tab, key_match_spec(key, now)) + acc
-    end)
+    {safe, unsafe} = Enum.split_with(keys, &safe_match_head_key?/1)
+
+    count =
+      Enum.reduce(safe, 0, fn key, acc ->
+        backend.select_delete(tab, key_match_spec(key, now)) + acc
+      end)
+
+    case unsafe do
+      [] -> count
+      _ -> count + backend.select_delete(tab, unsafe_keys_match_spec(unsafe, now))
+    end
   end
 
   defp return({:ok, entry(value: value)}, :value) do
@@ -1765,6 +1801,37 @@ defmodule Nebulex.Adapters.Local do
         }
       ]
     end
+  end
+
+  # Match spec for a batch of keys that can't be bound in the match head
+  # (see `safe_match_head_key?/1`). All such keys are matched with a single
+  # scan (one `:orelse`-chained guard), instead of one scan per key.
+  defp unsafe_keys_match_spec(keys, now) do
+    [
+      {
+        entry(key: :"$1", value: :_, touched: :_, exp: :"$4", tag: :_),
+        [key_in_guard(keys), not_expired(now)],
+        [true]
+      }
+    ]
+  end
+
+  defp unsafe_keys_match_spec(keys, select, now) do
+    [
+      {
+        entry(key: :"$1", value: :"$2", touched: :_, exp: :"$4", tag: :_),
+        [key_in_guard(keys), not_expired(now)],
+        [match_return(select)]
+      }
+    ]
+  end
+
+  defp key_in_guard([key]) do
+    {:"=:=", :"$1", {:const, key}}
+  end
+
+  defp key_in_guard([key | rest]) do
+    {:orelse, {:"=:=", :"$1", {:const, key}}, key_in_guard(rest)}
   end
 
   defp not_expired(now) do

--- a/lib/nebulex/adapters/local.ex
+++ b/lib/nebulex/adapters/local.ex
@@ -250,7 +250,7 @@ defmodule Nebulex.Adapters.Local do
   However, there are some predefined or shorthand queries you can use. See the
   ["Predefined queries"](#module-predefined-queries) section for information.
 
-  The adapter defines an entry as a tuple `{:entry, key, value, touched, ttl, tag}`,
+  The adapter defines an entry as a tuple `{:entry, key, value, touched, exp, tag}`,
   meaning the match pattern within the ETS Match Spec must be like
   `{:entry, :"$1", :"$2", :"$3", :"$4", :"$5"}`. To make query building easier,
   you can use the `Ex2ms` library.
@@ -275,6 +275,20 @@ defmodule Nebulex.Adapters.Local do
       {:ok, [{:b, 2}, {:c, 3}]}
 
   > You can use the `Ex2ms` or `MatchSpec` library to build queries easier.
+
+  ### `{:in, keys}` queries
+
+  Queries with `{:in, keys}` (e.g., `MyCache.get_all(in: keys)`) are executed
+  as key-indexed operations, one per key, so their cost is proportional to the
+  number of given keys (`O(keys)`) regardless of the cache size. Duplicated
+  keys in the list are processed only once. Bear in mind:
+
+    * `get_all` behaves like `fetch/2` on each key: if an entry is found in
+      the older generation, it is moved into the newer one, and expired
+      entries are lazily removed on read.
+    * `count_all` and `delete_all` neither count nor delete expired entries.
+    * `stream` is read-only; it does not move entries across generations nor
+      remove expired ones.
 
   ## Building Match Specs with QueryHelper
 
@@ -898,9 +912,6 @@ defmodule Nebulex.Adapters.Local do
     # Resolve the backend to be used
     backend = Keyword.fetch!(opts, :backend)
 
-    # Internal option for max nested match specs based on number of keys
-    purge_chunk_size = Keyword.fetch!(opts, :purge_chunk_size)
-
     # Build adapter metadata
     adapter_meta = %{
       name: opts[:name] || cache,
@@ -909,7 +920,6 @@ defmodule Nebulex.Adapters.Local do
       meta_tab: meta_tab,
       stats_counter: stats_counter,
       backend: backend,
-      purge_chunk_size: purge_chunk_size,
       started_at: DateTime.utc_now()
     }
 
@@ -1008,7 +1018,6 @@ defmodule Nebulex.Adapters.Local do
         on_write,
         adapter_meta.meta_tab,
         adapter_meta.backend,
-        adapter_meta.purge_chunk_size,
         Enum.map(
           entries,
           &entry(key: elem(&1, 0), value: elem(&1, 1), touched: now, exp: exp, tag: tag)
@@ -1018,12 +1027,12 @@ defmodule Nebulex.Adapters.Local do
     end)
   end
 
-  defp do_put_all(:put, meta_tab, backend, chunk_size, entries) do
-    put_entries(meta_tab, backend, entries, chunk_size)
+  defp do_put_all(:put, meta_tab, backend, entries) do
+    put_entries(meta_tab, backend, entries)
   end
 
-  defp do_put_all(:put_new, meta_tab, backend, chunk_size, entries) do
-    put_new_entries(meta_tab, backend, entries, chunk_size)
+  defp do_put_all(:put_new, meta_tab, backend, entries) do
+    put_new_entries(meta_tab, backend, entries)
   end
 
   @impl true
@@ -1179,16 +1188,18 @@ defmodule Nebulex.Adapters.Local do
   defp do_execute(
          %{meta_tab: meta_tab, backend: backend},
          %{op: :count_all, query: {:in, keys}},
-         opts
+         _opts
        )
        when is_list(keys) do
-    chunk_size = Keyword.get(opts, :chunk_size, 10)
+    keys = Enum.uniq(keys)
 
     with_retry(fn ->
+      now = Time.now()
+
       meta_tab
       |> list_gen()
       |> Enum.reduce(0, fn gen, acc ->
-        do_count_all(backend, gen, keys, chunk_size) + acc
+        do_count_all(backend, gen, keys, now) + acc
       end)
       |> wrap_ok()
     end)
@@ -1197,34 +1208,39 @@ defmodule Nebulex.Adapters.Local do
   defp do_execute(
          %{meta_tab: meta_tab, backend: backend},
          %{op: :delete_all, query: {:in, keys}},
-         opts
+         _opts
        )
        when is_list(keys) do
-    chunk_size = Keyword.get(opts, :chunk_size, 10)
+    keys = Enum.uniq(keys)
 
     with_retry(fn ->
+      now = Time.now()
+
       meta_tab
       |> list_gen()
       |> Enum.reduce(0, fn gen, acc ->
-        do_delete_all(backend, gen, keys, chunk_size) + acc
+        do_delete_all(backend, gen, keys, now) + acc
       end)
       |> wrap_ok()
     end)
   end
 
   defp do_execute(
-         %{meta_tab: meta_tab, backend: backend},
+         %{name: name, meta_tab: meta_tab, backend: backend},
          %{op: :get_all, query: {:in, keys}, select: select},
-         opts
+         _opts
        )
        when is_list(keys) do
-    chunk_size = Keyword.get(opts, :chunk_size, 10)
+    keys = Enum.uniq(keys)
 
     with_retry(fn ->
-      meta_tab
-      |> list_gen()
-      |> Enum.reduce([], fn gen, acc ->
-        do_get_all(backend, gen, keys, match_return(select), chunk_size) ++ acc
+      generations = list_gen(meta_tab)
+
+      keys
+      |> Enum.flat_map(fn key ->
+        generations
+        |> do_fetch(name, backend, key)
+        |> select_entries(select)
       end)
       |> wrap_ok()
     end)
@@ -1266,13 +1282,9 @@ defmodule Nebulex.Adapters.Local do
          opts
        ) do
     keys
+    |> Stream.uniq()
     |> Stream.chunk_every(Keyword.fetch!(opts, :max_entries))
-    |> Stream.map(fn chunk ->
-      meta_tab
-      |> list_gen()
-      |> Enum.reduce([], &(backend.select(&1, in_match_spec(chunk, select)) ++ &2))
-    end)
-    |> Stream.flat_map(& &1)
+    |> Stream.flat_map(&select_keys(meta_tab, backend, &1, select))
     |> wrap_ok()
   end
 
@@ -1309,6 +1321,17 @@ defmodule Nebulex.Adapters.Local do
       end,
       & &1
     )
+  end
+
+  defp select_keys(meta_tab, backend, keys, select) do
+    now = Time.now()
+    generations = list_gen(meta_tab)
+
+    Enum.flat_map(keys, fn key ->
+      ms = key_match_spec(key, select, now)
+
+      Enum.flat_map(generations, &backend.select(&1, ms))
+    end)
   end
 
   ## Nebulex.Adapter.Info
@@ -1407,9 +1430,7 @@ defmodule Nebulex.Adapters.Local do
       fetch_entry: 4,
       pop_entry: 4,
       list_gen: 1,
-      newer_gen: 1,
-      entry_keys: 1,
-      match_key: 2
+      newer_gen: 1
     ]
   ]
 
@@ -1478,10 +1499,6 @@ defmodule Nebulex.Adapters.Local do
     |> hd()
   end
 
-  defp entry_keys(entries) do
-    Enum.map(entries, fn entry(key: key) -> key end)
-  end
-
   defp validate_exp(entry(key: key, exp: exp) = entry, backend, tab, name) do
     if Time.now() >= exp do
       true = backend.delete(tab, key)
@@ -1526,12 +1543,8 @@ defmodule Nebulex.Adapters.Local do
     end
   end
 
-  defp put_entries(meta_tab, backend, entries, chunk_size) when is_list(entries) do
-    do_put_entries(meta_tab, backend, entries, fn older_gen ->
-      keys = Enum.map(entries, fn entry(key: key) -> key end)
-
-      do_delete_all(backend, older_gen, keys, chunk_size)
-    end)
+  defp put_entries(meta_tab, backend, entries) when is_list(entries) do
+    do_put_entries(meta_tab, backend, entries, &purge_older_gen(backend, &1, entries))
   end
 
   defp do_put_entries(meta_tab, backend, entry_or_entries, purge_fun) do
@@ -1546,9 +1559,7 @@ defmodule Nebulex.Adapters.Local do
     end
   end
 
-  defp put_new_entries(meta_tab, backend, entries, chunk_size \\ 0)
-
-  defp put_new_entries(meta_tab, backend, entry(key: key) = entry, _chunk_size) do
+  defp put_new_entries(meta_tab, backend, entry(key: key) = entry) do
     do_put_new_entries(meta_tab, backend, entry, fn newer_gen, older_gen ->
       with true <- backend.insert_new(older_gen, entry) do
         true = backend.delete(older_gen, key)
@@ -1558,16 +1569,19 @@ defmodule Nebulex.Adapters.Local do
     end)
   end
 
-  defp put_new_entries(meta_tab, backend, entries, chunk_size) when is_list(entries) do
+  defp put_new_entries(meta_tab, backend, entries) when is_list(entries) do
     do_put_new_entries(meta_tab, backend, entries, fn newer_gen, older_gen ->
       with true <- backend.insert_new(older_gen, entries) do
-        keys = entry_keys(entries)
-
-        _ = do_delete_all(backend, older_gen, keys, chunk_size)
+        :ok = purge_older_gen(backend, older_gen, entries)
 
         backend.insert_new(newer_gen, entries)
       end
     end)
+  end
+
+  # Removes the given entries' keys from the older generation.
+  defp purge_older_gen(backend, older_gen, entries) do
+    Enum.each(entries, fn entry(key: key) -> backend.delete(older_gen, key) end)
   end
 
   defp do_put_new_entries(meta_tab, backend, entry_or_entries, purge_fun) do
@@ -1607,118 +1621,16 @@ defmodule Nebulex.Adapters.Local do
     end)
   end
 
-  defp do_count_all(backend, tab, keys, chunk_size) do
-    ets_select_keys(
-      keys,
-      chunk_size,
-      0,
-      &new_match_spec/1,
-      &backend.select_count(tab, &1),
-      &(&1 + &2)
-    )
+  defp do_count_all(backend, tab, keys, now) do
+    Enum.reduce(keys, 0, fn key, acc ->
+      backend.select_count(tab, key_match_spec(key, now)) + acc
+    end)
   end
 
-  defp do_delete_all(backend, tab, keys, chunk_size) do
-    ets_select_keys(
-      keys,
-      chunk_size,
-      0,
-      &new_match_spec/1,
-      &backend.select_delete(tab, &1),
-      &(&1 + &2)
-    )
-  end
-
-  defp do_get_all(backend, tab, keys, select, chunk_size) do
-    ets_select_keys(
-      keys,
-      chunk_size,
-      [],
-      &new_match_spec(&1, select),
-      &backend.select(tab, &1),
-      &Kernel.++/2
-    )
-  end
-
-  defp ets_select_keys([k], chunk_size, acc, ms_fun, chunk_fun, after_fun) do
-    k = if is_tuple(k), do: tuple_to_match_spec(k), else: k
-
-    ets_select_keys(
-      [],
-      2,
-      chunk_size,
-      match_key(k, Time.now()),
-      acc,
-      ms_fun,
-      chunk_fun,
-      after_fun
-    )
-  end
-
-  defp ets_select_keys([k1, k2 | keys], chunk_size, acc, ms_fun, chunk_fun, after_fun) do
-    k1 = if is_tuple(k1), do: tuple_to_match_spec(k1), else: k1
-    k2 = if is_tuple(k2), do: tuple_to_match_spec(k2), else: k2
-    now = Time.now()
-
-    ets_select_keys(
-      keys,
-      2,
-      chunk_size,
-      {:orelse, match_key(k1, now), match_key(k2, now)},
-      acc,
-      ms_fun,
-      chunk_fun,
-      after_fun
-    )
-  end
-
-  defp ets_select_keys([], _count, _chunk_size, chunk_acc, acc, ms_fun, chunk_fun, after_fun) do
-    chunk_acc
-    |> ms_fun.()
-    |> chunk_fun.()
-    |> after_fun.(acc)
-  end
-
-  defp ets_select_keys(keys, count, chunk_size, chunk_acc, acc, ms_fun, chunk_fun, after_fun)
-       when count >= chunk_size do
-    acc =
-      chunk_acc
-      |> ms_fun.()
-      |> chunk_fun.()
-      |> after_fun.(acc)
-
-    ets_select_keys(keys, chunk_size, acc, ms_fun, chunk_fun, after_fun)
-  end
-
-  defp ets_select_keys([k | keys], count, chunk_size, chunk_acc, acc, ms_fun, chunk_fun, after_fun) do
-    k = if is_tuple(k), do: tuple_to_match_spec(k), else: k
-
-    ets_select_keys(
-      keys,
-      count + 1,
-      chunk_size,
-      {:orelse, chunk_acc, match_key(k, Time.now())},
-      acc,
-      ms_fun,
-      chunk_fun,
-      after_fun
-    )
-  end
-
-  defp tuple_to_match_spec(data) do
-    data
-    |> :erlang.tuple_to_list()
-    |> tuple_to_match_spec([])
-  end
-
-  defp tuple_to_match_spec([], acc) do
-    {acc |> Enum.reverse() |> :erlang.list_to_tuple()}
-  end
-
-  defp tuple_to_match_spec([e | tail], acc) do
-    e = if is_tuple(e), do: tuple_to_match_spec(e), else: e
-
-    tuple_to_match_spec(tail, [e | acc])
+  defp do_delete_all(backend, tab, keys, now) do
+    Enum.reduce(keys, 0, fn key, acc ->
+      backend.select_delete(tab, key_match_spec(key, now)) + acc
+    end)
   end
 
   defp return({:ok, entry(value: value)}, :value) do
@@ -1732,6 +1644,22 @@ defmodule Nebulex.Adapters.Local do
   defp return(other, _field) do
     other
   end
+
+  defp select_entries({:ok, entries}, select) when is_list(entries) do
+    for entry(key: key, value: value) <- entries, do: entry_return(select, key, value)
+  end
+
+  defp select_entries({:ok, entry(key: key, value: value)}, select) do
+    [entry_return(select, key, value)]
+  end
+
+  defp select_entries({:error, _}, _select) do
+    []
+  end
+
+  defp entry_return(:key, key, _value), do: key
+  defp entry_return(:value, _key, value), do: value
+  defp entry_return({:key, :value}, key, value), do: {key, value}
 
   defp assert_match_spec(spec, select) when spec in [nil, :expired] do
     [
@@ -1765,7 +1693,7 @@ defmodule Nebulex.Adapters.Local do
   end
 
   defp comp_match_spec(nil) do
-    {:orelse, {:"=:=", :"$4", :infinity}, {:<, Time.now(), :"$4"}}
+    not_expired(Time.now())
   end
 
   defp comp_match_spec(:expired) do
@@ -1781,32 +1709,6 @@ defmodule Nebulex.Adapters.Local do
     match_spec
   end
 
-  defp in_match_spec([k], select) do
-    match_key(k, Time.now())
-    |> new_match_spec(match_return(select))
-  end
-
-  defp in_match_spec([k1, k2 | keys], select) do
-    now = Time.now()
-
-    keys
-    |> Enum.reduce(
-      {:orelse, match_key(k1, now), match_key(k2, now)},
-      &{:orelse, &2, match_key(&1, now)}
-    )
-    |> new_match_spec(match_return(select))
-  end
-
-  defp new_match_spec(conds, return \\ true) do
-    [
-      {
-        entry(key: :"$1", value: :"$2", touched: :"$3", exp: :"$4"),
-        [conds],
-        [return]
-      }
-    ]
-  end
-
   defp match_return(select) do
     case select do
       :key -> :"$1"
@@ -1815,8 +1717,84 @@ defmodule Nebulex.Adapters.Local do
     end
   end
 
-  defp match_key(k, now) do
-    {:andalso, {:"=:=", :"$1", k}, {:orelse, {:"=:=", :"$4", :infinity}, {:<, now, :"$4"}}}
+  # Match spec helpers for `{:in, keys}` queries. The key is bound directly
+  # in the match head so ETS can use the key index; a guard-only key
+  # comparison would force a full table scan.
+  defp key_match_spec(key, now) do
+    if safe_match_head_key?(key) do
+      [
+        {
+          entry(key: key, value: :_, touched: :_, exp: :"$4", tag: :_),
+          [not_expired(now)],
+          [true]
+        }
+      ]
+    else
+      [
+        {
+          entry(key: :"$1", value: :_, touched: :_, exp: :"$4", tag: :_),
+          [{:"=:=", :"$1", {:const, key}}, not_expired(now)],
+          [true]
+        }
+      ]
+    end
+  end
+
+  defp key_match_spec(key, select, now) do
+    if safe_match_head_key?(key) do
+      return =
+        case select do
+          :key -> {:const, key}
+          :value -> :"$2"
+          {:key, :value} -> {{{:const, key}, :"$2"}}
+        end
+
+      [
+        {
+          entry(key: key, value: :"$2", touched: :_, exp: :"$4", tag: :_),
+          [not_expired(now)],
+          [return]
+        }
+      ]
+    else
+      [
+        {
+          entry(key: :"$1", value: :"$2", touched: :_, exp: :"$4", tag: :_),
+          [{:"=:=", :"$1", {:const, key}}, not_expired(now)],
+          [match_return(select)]
+        }
+      ]
+    end
+  end
+
+  defp not_expired(now) do
+    {:orelse, {:"=:=", :"$4", :infinity}, {:<, now, :"$4"}}
+  end
+
+  # ETS treats the atom `:_` as a wildcard and `:"$N"` atoms as match
+  # variables when they appear in a match head, and map patterns match
+  # partially. Keys containing any of those terms fall back to an exact
+  # (but unindexed) `{:const, key}` guard comparison.
+  defp safe_match_head_key?(key) when is_atom(key) do
+    key != :_ and not match?("$" <> _, Atom.to_string(key))
+  end
+
+  defp safe_match_head_key?(key) when is_tuple(key) do
+    key
+    |> Tuple.to_list()
+    |> Enum.all?(&safe_match_head_key?/1)
+  end
+
+  defp safe_match_head_key?([h | t]) do
+    safe_match_head_key?(h) and safe_match_head_key?(t)
+  end
+
+  defp safe_match_head_key?(key) when is_map(key) do
+    false
+  end
+
+  defp safe_match_head_key?(_key) do
+    true
   end
 
   defp test_ms, do: entry(key: 1, value: 1, touched: Time.now(), exp: 1000)

--- a/lib/nebulex/adapters/local/options.ex
+++ b/lib/nebulex/adapters/local/options.ex
@@ -80,8 +80,10 @@ defmodule Nebulex.Adapters.Local.Options do
       required: false,
       default: 100,
       doc: """
-      This option limits the max nested match specs based on the number of keys
-      when purging the older cache generation.
+      Deprecated: This option is no longer used and will be removed in the
+      next major release. Purging the older generation on `put_all` and
+      `put_new_all` is now done with per-key deletes, which do not require
+      chunking.
       """
     ],
     gc_interval: [

--- a/test/nebulex/adapters/local/info_stats_test.exs
+++ b/test/nebulex/adapters/local/info_stats_test.exs
@@ -115,10 +115,13 @@ defmodule Nebulex.Adapters.Local.InfoStatsTest do
 
       _ = t_sleep(1100)
 
-      # The `get_all` doesn't trigger the expiration
+      # The `get_all` triggers the lazy expiration and removes the expired
+      # entries. However, since it is an adapter-internal removal, it is not
+      # reflected in the expiration/deletion stats.
       assert Cache.get_all!(in: [:a, :b, :c, :d]) |> Map.new() == %{a: 1, b: 2}
 
-      # The `get` will trigger the expiration
+      # The expired entries were already removed by `get_all`, hence, the
+      # `get` calls are plain misses (no expirations/deletions counted).
       refute Cache.get!(:c)
       refute Cache.get!(:d)
 
@@ -127,9 +130,9 @@ defmodule Nebulex.Adapters.Local.InfoStatsTest do
                  hits: 6,
                  misses: 4,
                  writes: 4,
-                 evictions: 2,
-                 expirations: 2,
-                 deletions: 2,
+                 evictions: 0,
+                 expirations: 0,
+                 deletions: 0,
                  updates: 0
                }
       end)

--- a/test/shared/local_test_case.exs
+++ b/test/shared/local_test_case.exs
@@ -454,6 +454,22 @@ defmodule Nebulex.Adapters.LocalTest do
         assert cache.count_all!() == 6
       end
 
+      test "queries with {:in, keys} batch reserved match-spec atoms with ordinary keys", %{
+        cache: cache
+      } do
+        :ok = cache.put_all(%{:a => 1, :b => 2, :"$1" => 3, {:_, :x} => 4, %{a: 1} => 5})
+
+        keys = [:a, :b, :"$1", {:_, :x}, %{a: 1}, :unknown]
+
+        expected = Enum.sort([{:a, 1}, {:b, 2}, {:"$1", 3}, {{:_, :x}, 4}, {%{a: 1}, 5}])
+
+        assert cache.get_all!(in: keys) |> Enum.sort() == expected
+        assert cache.stream!(in: keys) |> Enum.sort() == expected
+        assert cache.count_all!(in: keys) == 5
+        assert cache.delete_all!(in: keys) == 5
+        assert cache.count_all!() == 0
+      end
+
       test "queries with {:in, keys} ignore duplicated keys", %{cache: cache} do
         :ok = cache.put_all(a: 1, b: 2)
 

--- a/test/shared/local_test_case.exs
+++ b/test/shared/local_test_case.exs
@@ -392,6 +392,77 @@ defmodule Nebulex.Adapters.LocalTest do
         assert cache.stream!(in: []) |> Enum.to_list() == []
       end
 
+      test "count_all with query {:in, keys}", %{cache: cache, name: name} do
+        :ok = cache.put_all(a: 1, b: 2, c: 3)
+
+        assert cache.count_all!(in: [:a, :b]) == 2
+        assert cache.count_all!(in: [:a, :b, :unknown]) == 2
+        assert cache.count_all!(in: []) == 0
+
+        _ = new_generation(cache, name)
+
+        :ok = cache.put(:d, 4)
+
+        assert cache.count_all!(in: [:a, :b, :c, :d]) == 4
+      end
+
+      test "count_all and delete_all with query {:in, keys} exclude expired entries", %{
+        cache: cache
+      } do
+        :ok = cache.put_all(a: 1, b: 2)
+        :ok = cache.put_all([c: 3, d: 4], ttl: 100)
+
+        _ = t_sleep(200)
+
+        assert cache.count_all!(in: [:a, :b, :c, :d]) == 2
+        assert cache.delete_all!(in: [:a, :b, :c, :d]) == 2
+      end
+
+      test "queries with {:in, keys} match tagged entries", %{cache: cache} do
+        :ok = cache.put_all([a: 1, b: 2, c: 3], tag: :foo)
+
+        assert cache.get_all!(in: [:a, :b, :c]) |> Enum.sort() == [a: 1, b: 2, c: 3]
+        assert cache.stream!(in: [:a, :b, :c]) |> Enum.sort() == [a: 1, b: 2, c: 3]
+        assert cache.count_all!(in: [:a, :b, :c]) == 3
+        assert cache.delete_all!(in: [:a, :b, :c]) == 3
+        assert cache.count_all!() == 0
+      end
+
+      test "stream with query {:in, keys} (tuple keys)", %{cache: cache} do
+        entries = [{{:a, 1}, 1}, {{:b, {:c, 3}}, 2}]
+
+        :ok = cache.put_all(entries)
+
+        assert cache.stream!(in: [{:a, 1}, {:b, {:c, 3}}]) |> Enum.sort() == Enum.sort(entries)
+      end
+
+      test "queries with {:in, keys} handle reserved match-spec atoms", %{cache: cache} do
+        :ok = cache.put_all(%{:_ => 1, :"$1" => 2, :a => 3, {:_, :x} => 4, %{a: 1} => 5})
+        :ok = cache.put(%{a: 1, b: 2}, 6)
+        :ok = cache.put([:a, :_], 7)
+
+        assert cache.get_all!(in: [:"$1"]) == [{:"$1", 2}]
+        assert cache.count_all!(in: [{:_, :x}]) == 1
+        assert cache.count_all!(in: [[:a, :_]]) == 1
+
+        # Map keys must match exactly (no partial matching)
+        assert cache.get_all!(in: [%{a: 1}]) == [{%{a: 1}, 5}]
+        assert cache.count_all!(in: [%{a: 1}]) == 1
+
+        # `:_` must be treated as a regular key, not as a wildcard
+        assert cache.delete_all!(in: [:_]) == 1
+        assert cache.count_all!() == 6
+      end
+
+      test "queries with {:in, keys} ignore duplicated keys", %{cache: cache} do
+        :ok = cache.put_all(a: 1, b: 2)
+
+        assert cache.get_all!(in: [:a, :a]) == [a: 1]
+        assert cache.stream!(in: [:a, :a]) |> Enum.to_list() == [a: 1]
+        assert cache.count_all!(in: [:a, :a, :b]) == 2
+        assert cache.delete_all!(in: [:a, :a, :b]) == 2
+      end
+
       test "QueryHelper: get_all with tag", %{cache: cache} do
         assert cache.put_all([a: 1, b: 2, c: 3], tag: :foo) == :ok
         assert cache.put_all([d: 4, e: 5, f: 6], tag: :bar) == :ok
@@ -782,6 +853,71 @@ defmodule Nebulex.Adapters.LocalTest do
 
         assert cache.count_all!() == 21
         assert cache.get_all!(select: :key) |> Enum.sort() == more_keys
+      end
+
+      test "get_all!/2 with {:in, keys} (entries are moved to the newer generation)", %{
+        cache: cache,
+        name: name
+      } do
+        entries = Enum.map(1..10, &{&1, &1})
+        keys = Enum.map(entries, &elem(&1, 0))
+
+        :ok = cache.put_all(entries)
+
+        _ = new_generation(cache, name)
+
+        Enum.each(entries, fn {k, v} ->
+          refute get_from_new(cache, name, k)
+          assert get_from_old(cache, name, k) == v
+        end)
+
+        assert cache.get_all!(in: keys) |> Enum.sort() == entries
+
+        Enum.each(entries, fn {k, v} ->
+          assert get_from_new(cache, name, k) == v
+          refute get_from_old(cache, name, k)
+        end)
+
+        _ = new_generation(cache, name)
+
+        assert cache.get_all!(in: keys) |> Enum.sort() == entries
+      end
+
+      test "get_all!/2 with {:in, keys} (expired entries are removed on read)", %{
+        cache: cache,
+        name: name
+      } do
+        :ok = cache.put(:a, 1)
+        :ok = cache.put(:b, 2, ttl: 100)
+
+        _ = new_generation(cache, name)
+        _ = t_sleep(200)
+
+        assert cache.get_all!(in: [:a, :b]) == [a: 1]
+
+        assert get_from_new(cache, name, :a) == 1
+        refute get_from_new(cache, name, :b)
+        refute get_from_old(cache, name, :b)
+      end
+
+      test "put_all/2 (tagged keys are removed from older generation)", %{
+        cache: cache,
+        name: name
+      } do
+        entries = [a: 1, b: 2]
+
+        :ok = cache.put_all(entries, tag: :foo)
+
+        _ = new_generation(cache, name)
+
+        :ok = cache.put_all(entries, tag: :foo)
+
+        Enum.each(entries, fn {k, v} ->
+          assert get_from_new(cache, name, k) == v
+          refute get_from_old(cache, name, k)
+        end)
+
+        assert cache.count_all!() == 2
       end
     end
 


### PR DESCRIPTION
Refs #8

## Summary

`get_all`, `count_all`, `delete_all`, and `stream` with `{:in, keys}` compiled the key list into chunked ETS match specs where key equality lived in the match **guard** rather than the match **head**. ETS only uses its key index when the key is bound in the head, so every chunk forced a full scan of every table generation — making these queries `O(table_size × keys)` instead of the `O(keys)` the multi-key API is supposed to provide.

On a 450k-entry cache, fetching 200 keys via `get_all(in: keys)` took **~1.4s**, versus **~0.11ms** for 200 equivalent `fetch/1` calls — a **~12,000x** difference. This is a regression from Nebulex 2, where `get_all/2` was implemented as per-key lookups; it surfaces immediately for anyone following the v3 migration guide's `get_all(keys)` → `get_all!(in: keys)` rewrite on a cache of non-trivial size.

This PR reimplements `{:in, keys}` as one match spec per key, with the key bound directly in the match head — so ETS resolves each key via its index — falling back to an exact `{:const, key}` guard only for keys that would otherwise collide with reserved match-spec syntax (`:_`, `:"$N"` atoms, maps).

## Root cause → fix, in one match spec

Before (key compared in a guard chain, arbitrary table scan):

```elixir
{:andalso, {:"=:=", :"$1", key}, {:orelse, {:"=:=", :"$4", :infinity}, {:<, now, :"$4"}}}
# head: entry(key: :"$1", value: :"$2", touched: :"$3", exp: :"$4")
```

After (key bound in the head, ETS uses its index):

```elixir
{
  entry(key: key, value: :"$2", touched: :_, exp: :"$4", tag: :_),
  [not_expired(now)],
  [match_return(select)]
}
```

## Changes

- **`lib/nebulex/adapters/local.ex`**
  - `{:in, keys}` for `get_all`, `count_all`, `delete_all`, and `stream` now resolves each key via its own indexed match spec (`key_match_spec/2`, `key_match_spec/3`) instead of chunked, OR'd guard clauses. Chunking and the `ets_select_keys`/`match_key`/`tuple_to_match_spec` helpers are removed entirely.
  - `get_all` with `{:in, keys}` now goes through the same per-key path as `fetch/2`: entries found in the older generation are moved into the newer one, and expired entries are lazily removed on read — restoring v2 read behavior. `count_all`/`delete_all` still don't count or delete expired entries, and `stream` remains read-only. Documented in the moduledoc under a new `{:in, keys}` queries section.
  - Duplicate keys in the input list are processed once (`Enum.uniq/1`).
  - Entries written with the `:tag` option are no longer silently excluded from `{:in, keys}` matches, and `stream/2` no longer crashes on tuple keys.
  - The older-generation purge in `put_all`/`put_new_all` uses the same per-key approach (`purge_older_gen/3`) instead of chunked match specs.

- **`lib/nebulex/adapters/local/options.ex`**
  - `:purge_chunk_size` is deprecated in the docs; it's no longer read by adapter setup or the put paths, so it's now a no-op.

- **`test/shared/local_test_case.exs`**, **`test/.../info_stats_test.exs`**
  - New coverage: generation migration and lazy expiration on `get_all`, tagged entries, tuple keys, reserved match-spec atoms/maps as literal keys, and duplicate-key handling.
  - Updated stats expectations: `get_all` with `{:in, keys}` now expires entries lazily *during* the query, so the `evictions`/`expirations`/`deletions` counters that used to bump on a follow-up `get` are `0` — the removal already happened, and adapter-internal removal isn't counted in those stats.

- **`CHANGELOG.md`** — added an `Unreleased` section documenting the fixes above.

- **`mix.lock`** — incidental `telemetry` bump (1.3.0 → 1.4.2), unrelated to this fix; flagged here so the otherwise-unexplained lockfile diff doesn't raise questions. Happy to split it into a separate PR if preferred.

## Testing

- `mix test`, including the new `{:in, keys}` and generation-behavior cases in `test/shared/local_test_case.exs` and the updated stats assertions in `test/nebulex/adapters/local/info_stats_test.exs`.
